### PR TITLE
[SGL-005] 企業一覧・検索・フォロー機能

### DIFF
--- a/src/app/(main)/discover/CompanySearch.tsx
+++ b/src/app/(main)/discover/CompanySearch.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useTransition } from 'react'
+
+export function CompanySearch() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const q = e.target.value.trim()
+      const params = new URLSearchParams(searchParams.toString())
+      if (q) {
+        params.set('q', q)
+      } else {
+        params.delete('q')
+      }
+      startTransition(() => {
+        router.push(`/discover?${params.toString()}`)
+      })
+    },
+    [router, searchParams],
+  )
+
+  return (
+    <div className="relative">
+      <input
+        type="search"
+        defaultValue={searchParams.get('q') ?? ''}
+        onChange={handleChange}
+        placeholder="企業名で検索..."
+        className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 pl-10 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      />
+      <svg
+        className="absolute top-1/2 left-3 -translate-y-1/2 text-gray-400"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.35-4.35" />
+      </svg>
+      {isPending && (
+        <div className="absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+      )}
+    </div>
+  )
+}

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -1,0 +1,107 @@
+import { ilike, or } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
+import Image from 'next/image'
+import { Suspense } from 'react'
+
+import { FollowButton } from '@/components/FollowButton'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { companies, follows } from '../../../../db/schema'
+import { CompanySearch } from './CompanySearch'
+
+interface PageProps {
+  searchParams: Promise<{ q?: string }>
+}
+
+export const metadata = { title: '企業を探す | Signalog' }
+
+export default async function DiscoverPage({ searchParams }: PageProps) {
+  const { q } = await searchParams
+  const query = q?.trim() ?? ''
+
+  const session = await auth()
+  const userId = session?.user.id ?? null
+
+  const [companyList, followedRows] = await Promise.all([
+    db
+      .select()
+      .from(companies)
+      .where(
+        query
+          ? or(ilike(companies.name, `%${query}%`), ilike(companies.slug, `%${query}%`))
+          : undefined,
+      )
+      .orderBy(companies.name)
+      .limit(100),
+    userId
+      ? db.select({ companyId: follows.companyId }).from(follows).where(eq(follows.userId, userId))
+      : Promise.resolve([]),
+  ])
+
+  const followedSet = new Set(followedRows.map((f) => f.companyId))
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mb-8">
+        <h1 className="mb-2 text-2xl font-bold text-gray-900">企業を探す</h1>
+        <p className="text-gray-500">気になる企業をフォローしてフィードをカスタマイズしよう</p>
+      </div>
+
+      <div className="mb-6">
+        <Suspense>
+          <CompanySearch />
+        </Suspense>
+      </div>
+
+      {companyList.length === 0 ? (
+        <p className="py-16 text-center text-gray-500">
+          {query ? `「${query}」に一致する企業が見つかりません` : '企業がまだ登録されていません'}
+        </p>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2">
+          {companyList.map((company) => (
+            <li
+              key={company.id}
+              className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              {company.logoUrl ? (
+                <Image
+                  src={company.logoUrl}
+                  alt={company.name}
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-md object-contain"
+                />
+              ) : (
+                <div className="flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 text-sm font-bold text-gray-400">
+                  {company.name[0]}
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium text-gray-900">{company.name}</p>
+                {company.description && (
+                  <p className="truncate text-sm text-gray-500">{company.description}</p>
+                )}
+              </div>
+              {userId ? (
+                <FollowButton
+                  companyId={company.id}
+                  initialFollowed={followedSet.has(company.id)}
+                />
+              ) : (
+                <a
+                  href="/login"
+                  className="rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+                >
+                  フォロー
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-4 text-right text-xs text-gray-400">{companyList.length} 社</p>
+    </main>
+  )
+}

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -1,0 +1,18 @@
+import { ilike, or } from 'drizzle-orm'
+import { type NextRequest } from 'next/server'
+
+import { db } from '@/lib/db/server'
+import { companies } from '../../../../db/schema'
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get('q')?.trim() ?? ''
+
+  const rows = await db
+    .select()
+    .from(companies)
+    .where(q ? or(ilike(companies.name, `%${q}%`), ilike(companies.slug, `%${q}%`)) : undefined)
+    .orderBy(companies.name)
+    .limit(100)
+
+  return Response.json({ data: rows })
+}

--- a/src/app/api/follows/route.ts
+++ b/src/app/api/follows/route.ts
@@ -1,0 +1,89 @@
+import { and, eq } from 'drizzle-orm'
+import { type NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { companies, follows } from '../../../../db/schema'
+
+const bodySchema = z.object({ companyId: z.string().uuid() })
+
+export async function GET() {
+  const session = await auth()
+  if (!session) {
+    return Response.json(
+      { error: { code: 'UNAUTHORIZED', message: 'ログインが必要です' } },
+      { status: 401 },
+    )
+  }
+
+  const rows = await db
+    .select({ companyId: follows.companyId })
+    .from(follows)
+    .where(eq(follows.userId, session.user.id))
+
+  return Response.json({ data: rows })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return Response.json(
+      { error: { code: 'UNAUTHORIZED', message: 'ログインが必要です' } },
+      { status: 401 },
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return Response.json(
+      { error: { code: 'BAD_REQUEST', message: '無効なリクエスト' } },
+      { status: 400 },
+    )
+  }
+
+  const { companyId } = parsed.data
+
+  const [company] = await db
+    .select({ id: companies.id })
+    .from(companies)
+    .where(eq(companies.id, companyId))
+    .limit(1)
+
+  if (!company) {
+    return Response.json(
+      { error: { code: 'NOT_FOUND', message: '企業が見つかりません' } },
+      { status: 404 },
+    )
+  }
+
+  await db.insert(follows).values({ userId: session.user.id, companyId }).onConflictDoNothing()
+
+  return Response.json({ data: { companyId } })
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await auth()
+  if (!session) {
+    return Response.json(
+      { error: { code: 'UNAUTHORIZED', message: 'ログインが必要です' } },
+      { status: 401 },
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return Response.json(
+      { error: { code: 'BAD_REQUEST', message: '無効なリクエスト' } },
+      { status: 400 },
+    )
+  }
+
+  const { companyId } = parsed.data
+
+  await db
+    .delete(follows)
+    .where(and(eq(follows.userId, session.user.id), eq(follows.companyId, companyId)))
+
+  return Response.json({ data: null })
+}

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState } from 'react'
+
+interface FollowButtonProps {
+  companyId: string
+  initialFollowed: boolean
+}
+
+export function FollowButton({ companyId, initialFollowed }: FollowButtonProps) {
+  const [followed, setFollowed] = useState(initialFollowed)
+  const [pending, setPending] = useState(false)
+
+  async function toggle() {
+    if (pending) return
+    setPending(true)
+    setFollowed((prev) => !prev)
+
+    try {
+      const res = await fetch('/api/follows', {
+        method: followed ? 'DELETE' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyId }),
+      })
+      if (!res.ok) setFollowed((prev) => !prev)
+    } catch {
+      setFollowed((prev) => !prev)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={pending}
+      className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+        followed
+          ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+          : 'bg-blue-600 text-white hover:bg-blue-700'
+      }`}
+    >
+      {followed ? 'フォロー中' : 'フォロー'}
+    </button>
+  )
+}

--- a/src/hooks/useFollows.ts
+++ b/src/hooks/useFollows.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+export function useFollows() {
+  const [followedIds, setFollowedIds] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/follows')
+      if (res.ok) {
+        const { data } = (await res.json()) as { data: { companyId: string }[] }
+        setFollowedIds(new Set(data.map((f) => f.companyId)))
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return { followedIds, loading, refresh }
+}


### PR DESCRIPTION
## 概要

企業一覧ページ (`/discover`)、企業検索、フォロー/アンフォロー機能を実装。

## 変更内容

| ファイル | 説明 |
|---|---|
| `src/app/(main)/discover/page.tsx` | 企業一覧 Server Component (searchParams で検索) |
| `src/app/(main)/discover/CompanySearch.tsx` | 検索フォーム Client Component (useTransition) |
| `src/components/FollowButton.tsx` | フォロー/アンフォロー Client Component (楽観的更新) |
| `src/hooks/useFollows.ts` | フォロー一覧取得フック |
| `src/app/api/companies/route.ts` | `GET /api/companies?q=` 企業検索 API |
| `src/app/api/follows/route.ts` | `GET/POST/DELETE /api/follows` フォロー CRUD |

## 実装詳細

- 検索: URL searchParams ベース → Server Component が ILIKE クエリを発行
- フォロー状態: サーバーで companies + follows を並列取得し `initialFollowed` を注入
- 楽観的更新: クリック即座に UI 反映、API 失敗時にロールバック
- 未ログイン時: フォローボタン → `/login` へリダイレクト、API → 401

## 依存

- SGL-003 (認証)
- SGL-004 (企業シードデータ)

## テスト方法

- [x] `/discover` で企業一覧が表示される
- [x] 検索フォームで「mercari」と入力するとフィルタされる
- [x] ログイン済みでフォローボタンを押すと即座に「フォロー中」になる
- [x] 未ログイン状態でフォロー API を叩くと 401
- [x] 同じ企業を2回フォローしても重複しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)