### PR TITLE
[SGL-008] マイページ (フォロー中一覧)

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,0 +1,117 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { eq } from 'drizzle-orm'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { FollowButton } from '@/components/FollowButton'
+import { companies, follows } from '../../../../db/schema'
+
+export const metadata = { title: 'マイページ | Signalog' }
+
+export default async function MyPage() {
+  const session = await auth()
+  if (!session) redirect('/login')
+
+  const followedCompanies = await db
+    .select({
+      id: companies.id,
+      slug: companies.slug,
+      name: companies.name,
+      logoUrl: companies.logoUrl,
+      description: companies.description,
+      followedAt: follows.createdAt,
+    })
+    .from(follows)
+    .innerJoin(companies, eq(follows.companyId, companies.id))
+    .where(eq(follows.userId, session.user.id))
+    .orderBy(follows.createdAt)
+
+  const user = session.user
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      {/* プロフィール */}
+      <section className="mb-8 flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        {user.image ? (
+          <Image
+            src={user.image}
+            alt={user.name ?? 'アバター'}
+            width={64}
+            height={64}
+            className="h-16 w-16 rounded-full"
+          />
+        ) : (
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200 text-2xl font-bold text-gray-500">
+            {user.name?.[0] ?? '?'}
+          </div>
+        )}
+        <div>
+          <p className="text-lg font-semibold text-gray-900">{user.name ?? '名前未設定'}</p>
+          <p className="text-sm text-gray-500">{user.email}</p>
+        </div>
+      </section>
+
+      {/* フォロー中企業 */}
+      <section>
+        <h2 className="mb-4 text-lg font-bold text-gray-900">
+          フォロー中の企業
+          <span className="ml-2 text-sm font-normal text-gray-400">
+            {followedCompanies.length} 社
+          </span>
+        </h2>
+
+        {followedCompanies.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="mb-4 text-gray-500">フォロー中の企業はまだありません</p>
+            <Link
+              href="/discover"
+              className="rounded-full bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              企業を探す
+            </Link>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {followedCompanies.map((company) => (
+              <li
+                key={company.id}
+                className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+              >
+                {company.logoUrl ? (
+                  <Image
+                    src={company.logoUrl}
+                    alt={company.name}
+                    width={40}
+                    height={40}
+                    className="h-10 w-10 rounded-md object-contain"
+                  />
+                ) : (
+                  <div className="flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 text-sm font-bold text-gray-400">
+                    {company.name[0]}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-gray-900">{company.name}</p>
+                  {company.description && (
+                    <p className="truncate text-sm text-gray-500">{company.description}</p>
+                  )}
+                  <p className="text-xs text-gray-400">
+                    フォロー:{' '}
+                    {company.followedAt.toLocaleDateString('ja-JP', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </p>
+                </div>
+                <FollowButton companyId={company.id} initialFollowed={true} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## 概要

マイページ `/mypage` を実装。フォロー中企業の確認・解除とプロフィール表示。

Closes #8

## 変更内容

| ファイル | 説明 |
|---|---|
| `src/app/(main)/mypage/page.tsx` | マイページ Server Component |

## 実装詳細

- 未ログイン → `/login` に redirect (server-side)
- プロフィール: セッションからアバター/名前/メールを表示
- フォロー中企業: `follows` JOIN `companies` で取得、フォロー日付付き
- アンフォロー: SGL-005 の `FollowButton` を流用 (`initialFollowed=true`)
- 空状態: `/discover` への誘導ボタン

## テスト方法

- [x] 未ログインで `/mypage` にアクセス → `/login` にリダイレクト
- [x] ログイン後にフォロー中企業が一覧表示される
- [x] アンフォローボタンを押すとリストから消える (楽観的更新)
- [x] フォロー0件のとき空状態 UI が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)