### PR TITLE
[SGL-UI] ワイヤーフレームに基づくUI全面刷新 + discover/authバグ修正

### DIFF
--- a/src/app/(main)/companies/[slug]/page.tsx
+++ b/src/app/(main)/companies/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { desc, eq, and } from 'drizzle-orm'
 
+import { CompanyLogo } from '@/components/CompanyLogo'
 import { FollowButton } from '@/components/FollowButton'
 import { ArticleCard } from '@/components/ArticleCard'
 import { auth } from '@/lib/auth'
@@ -32,7 +33,7 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
   if (!company) notFound()
 
   const session = await auth()
-  const userId = session?.user.id ?? null
+  const userId = session?.user?.id ?? null
 
   const [articleRows, followedRows] = await Promise.all([
     db
@@ -99,23 +100,12 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
 
       {/* Company header card */}
       <section className="border-sg-line bg-sg-surface mb-6 flex items-center gap-4 rounded-2xl border p-6">
-        {company.logoUrl ? (
-          /* eslint-disable-next-line @next/next/no-img-element */
-          <img
-            src={company.logoUrl}
-            alt={company.name}
-            width={56}
-            height={56}
-            className="h-14 w-14 shrink-0 rounded-xl object-contain"
-            onError={(e) => {
-              ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-            }}
-          />
-        ) : (
-          <div className="bg-sg-accent-soft text-sg-accent-deep flex h-14 w-14 shrink-0 items-center justify-center rounded-xl text-lg font-black">
-            {company.name.slice(0, 2)}
-          </div>
-        )}
+        <CompanyLogo
+          name={company.name}
+          logoUrl={company.logoUrl}
+          imgClassName="h-14 w-14 shrink-0 rounded-xl object-contain"
+          tileClassName="bg-sg-accent-soft text-sg-accent-deep flex h-14 w-14 shrink-0 items-center justify-center rounded-xl text-lg font-black"
+        />
         <div className="min-w-0 flex-1">
           <h1 className="text-sg-ink text-xl font-black">{company.name}</h1>
           {company.description && (

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -2,6 +2,7 @@ import { ilike, or, eq } from 'drizzle-orm'
 import Link from 'next/link'
 import { Suspense } from 'react'
 
+import { CompanyLogo } from '@/components/CompanyLogo'
 import { FollowButton } from '@/components/FollowButton'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db/server'
@@ -19,7 +20,7 @@ export default async function DiscoverPage({ searchParams }: PageProps) {
   const query = q?.trim() ?? ''
 
   const session = await auth()
-  const userId = session?.user.id ?? null
+  const userId = session?.user?.id ?? null
 
   const [companyList, followedRows] = await Promise.all([
     db
@@ -64,23 +65,12 @@ export default async function DiscoverPage({ searchParams }: PageProps) {
                 key={company.id}
                 className="border-sg-line bg-sg-surface flex items-center gap-3 rounded-2xl border p-4 transition-shadow hover:shadow-sm"
               >
-                {company.logoUrl ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img
-                    src={company.logoUrl}
-                    alt={company.name}
-                    width={44}
-                    height={44}
-                    className="h-11 w-11 shrink-0 rounded-xl object-contain"
-                    onError={(e) => {
-                      ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-                    }}
-                  />
-                ) : (
-                  <div className="bg-sg-accent-soft text-sg-accent-deep flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-sm font-bold">
-                    {company.name.slice(0, 2)}
-                  </div>
-                )}
+                <CompanyLogo
+                  name={company.name}
+                  logoUrl={company.logoUrl}
+                  imgClassName="h-11 w-11 shrink-0 rounded-xl object-contain"
+                  tileClassName="bg-sg-accent-soft text-sg-accent-deep flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-sm font-bold"
+                />
                 <div className="min-w-0 flex-1">
                   <Link
                     href={`/companies/${company.slug}`}

--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -24,7 +24,7 @@ export default async function FeedPage({ searchParams }: PageProps) {
   const type: FeedType = typeParam === 'tech' || typeParam === 'press' ? typeParam : 'all'
 
   const session = await auth()
-  const userId = session?.user.id ?? null
+  const userId = session?.user?.id ?? null
   const following = followingParam !== 'false' && userId !== null
 
   let followedCompanyIds: string[] | null = null

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
   const cursor = cursorParam ? decodeCursor(cursorParam) : null
 
   const session = await auth()
-  const userId = session?.user.id ?? null
+  const userId = session?.user?.id ?? null
 
   // フォロー中フィルタ: ログイン済みかつ following=true のとき
   let followedCompanyIds: string[] | null = null

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 
 import type { ArticleWithCompany } from '@/app/api/feed/route'

--- a/src/components/CompanyLogo.tsx
+++ b/src/components/CompanyLogo.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  name: string
+  logoUrl: string | null
+  imgClassName?: string
+  tileClassName?: string
+}
+
+export function CompanyLogo({ name, logoUrl, imgClassName, tileClassName }: Props) {
+  const [error, setError] = useState(false)
+
+  if (logoUrl && !error) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={logoUrl} alt={name} className={imgClassName} onError={() => setError(true)} />
+    )
+  }
+  return <div className={tileClassName}>{name.slice(0, 2)}</div>
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ declare module 'next-auth' {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  trustHost: true,
   adapter: DrizzleAdapter(db, {
     usersTable: users,
     accountsTable: accounts,


### PR DESCRIPTION
## 関連 Issue

Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34

## 変更内容

ワイヤーフレーム設計に基づくUI全面刷新と、それに伴うバグ修正。

**レイアウト**
- グローバルレイアウトをTopBar + サイドバーナビ構成に刷新 (`src/app/(main)/layout.tsx`)
- `TopBar.tsx`, `Sidebar.tsx`, `SidebarNav.tsx` を新規作成、旧 `Header.tsx` を削除
- デザイントークン (`--color-sg-*`) を `globals.css` に追加

**ページ単位の変更**
- ログインページ: 左ペイン（価値訴求コピー + ロゴタイル）＋右ペイン（OAuth）の2カラム構成
- フィードページ: ピルチップフィルター（Tech Blog / Press / フォロー中）
- 企業一覧ページ: 2列グリッド + アクセントカラーフォローボタン
- マイページ: プロフィールカード + フォロー中企業一覧
- 企業詳細ページ: `/companies/[slug]` 新規作成（ヘッダーカード + タブ + 記事一覧）

**バグ修正**
- `CompanyLogo.tsx` を Client Component として新規作成し、Server Component 内の `<img onError>` を排除（discover ページの RSC エラー解消）
- `ArticleCard.tsx` に `'use client'` を追加（OGP 画像の onError も解消）
- `auth.ts` に `trustHost: true` を追加（ローカル開発時の UntrustedHost エラー解消）
- `session?.user.id` → `session?.user?.id` に修正（discover ページの TypeError 解消）

## 仕様書

- `docs/phase1-spec-revised.md`

## テスト方法

1. `pnpm dev` で起動
2. `/discover` に遷移 → 企業一覧が表示されること（以前は HTTP 500）
3. 企業をフォローして `/feed` に移動 → 記事が表示されること
4. `/companies/[slug]` に遷移 → 企業詳細ページが表示されること
5. 未ログイン状態で各ページを確認 → サイドバー・ヘッダーが正常に表示されること

## スクリーンショット

（Vercel プレビューデプロイで確認）

## セルフチェック

- [x] CI が通っている
- [x] 仕様書の完了条件をすべて満たしている
- [x] `console.log` などのデバッグコードを削除した
- [x] シークレットがハードコードされていない
- [x] 認可が必要な API に `auth()` 呼び出しがある
- [x] ユーザー入力に Zod バリデーションがある
- [x] エラーハンドリングがある

## 仕様からの逸脱

なし