### PR TITLE
[Security] XSS対策URLプロトコル検証 + 検索クエリ長制限

### DIFF
--- a/src/app/(main)/mypage/FollowedCompaniesList.tsx
+++ b/src/app/(main)/mypage/FollowedCompaniesList.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 
+import { CompanyLogo } from '@/components/CompanyLogo'
 import { FollowButton } from '@/components/FollowButton'
 
 interface FollowedCompany {
@@ -38,23 +39,12 @@ export function FollowedCompaniesList({ initialList }: { initialList: FollowedCo
           key={company.id}
           className="border-sg-line bg-sg-surface flex items-center gap-3 rounded-2xl border p-4"
         >
-          {company.logoUrl ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
-              src={company.logoUrl}
-              alt={company.name}
-              width={44}
-              height={44}
-              className="h-11 w-11 shrink-0 rounded-xl object-contain"
-              onError={(e) => {
-                ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-              }}
-            />
-          ) : (
-            <div className="bg-sg-accent-soft text-sg-accent-deep flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-sm font-bold">
-              {company.name.slice(0, 2)}
-            </div>
-          )}
+          <CompanyLogo
+            name={company.name}
+            logoUrl={company.logoUrl}
+            imgClassName="h-11 w-11 shrink-0 rounded-xl object-contain"
+            tileClassName="bg-sg-accent-soft text-sg-accent-deep flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-sm font-bold"
+          />
           <div className="min-w-0 flex-1">
             <Link
               href={`/companies/${company.slug}`}

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db/server'
 import { companies } from '../../../../db/schema'
 
 export async function GET(request: NextRequest) {
-  const q = request.nextUrl.searchParams.get('q')?.trim() ?? ''
+  const q = (request.nextUrl.searchParams.get('q')?.trim() ?? '').slice(0, 100)
 
   const rows = await db
     .select()

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import { isSafeUrl } from '@/lib/safeUrl'
 import type { ArticleWithCompany } from '@/app/api/feed/route'
 
 function formatRelative(iso: string) {
@@ -16,7 +17,7 @@ function formatRelative(iso: string) {
 }
 
 function LogoTile({ name, logoUrl }: { name: string; logoUrl: string | null }) {
-  if (logoUrl) {
+  if (isSafeUrl(logoUrl)) {
     return (
       /* eslint-disable-next-line @next/next/no-img-element */
       <img
@@ -39,9 +40,10 @@ function LogoTile({ name, logoUrl }: { name: string; logoUrl: string | null }) {
 }
 
 export function ArticleCard({ article }: { article: ArticleWithCompany }) {
+  const safeSourceUrl = isSafeUrl(article.sourceUrl) ? article.sourceUrl : '#'
   return (
     <a
-      href={article.sourceUrl}
+      href={safeSourceUrl}
       target="_blank"
       rel="noopener noreferrer"
       className="group border-sg-line bg-sg-surface hover:border-sg-accent-soft flex gap-4 rounded-2xl border p-4 transition-all hover:shadow-sm"
@@ -74,7 +76,7 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
         </p>
       </div>
 
-      {article.ogpImageUrl && (
+      {isSafeUrl(article.ogpImageUrl) && (
         <div className="hidden shrink-0 sm:block">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img

--- a/src/components/CompanyLogo.tsx
+++ b/src/components/CompanyLogo.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 
+import { isSafeUrl } from '@/lib/safeUrl'
+
 interface Props {
   name: string
   logoUrl: string | null
@@ -12,7 +14,7 @@ interface Props {
 export function CompanyLogo({ name, logoUrl, imgClassName, tileClassName }: Props) {
   const [error, setError] = useState(false)
 
-  if (logoUrl && !error) {
+  if (isSafeUrl(logoUrl) && !error) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
       <img src={logoUrl} alt={name} className={imgClassName} onError={() => setError(true)} />

--- a/src/lib/safeUrl.ts
+++ b/src/lib/safeUrl.ts
@@ -1,0 +1,9 @@
+export function isSafeUrl(url: string | null | undefined): url is string {
+  if (!url) return false
+  try {
+    const { protocol } = new URL(url)
+    return protocol === 'https:' || protocol === 'http:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #37
Closes #39

## 変更内容

脆弱性診断で検出された HIGH/MEDIUM 2件の即時対応。

**URL プロトコル検証 (#37)**
- `src/lib/safeUrl.ts` を新規作成 — `http:` / `https:` 以外のURLを拒否するユーティリティ
- `CompanyLogo.tsx` — `logoUrl` に `isSafeUrl()` ガードを追加
- `ArticleCard.tsx` — `logoUrl`・`ogpImageUrl`・`sourceUrl` に `isSafeUrl()` ガードを追加
- `FollowedCompaniesList.tsx` — `img` 直書きを `<CompanyLogo>` に統一（ガード込み）

**検索クエリ長制限 (#39)**
- `/api/companies` の `q` パラメータを `.slice(0, 100)` で100文字に制限

## 仕様書

セキュリティ対応のため仕様書対象外。

## テスト方法

1. `pnpm dev` で起動
2. `/discover` → 企業ロゴが正常表示されること
3. DevTools でネットワーク確認 — `javascript:` URIのリクエストが発生しないこと
4. `/api/companies?q=` に100文字超の文字列を渡しても正常レスポンスが返ること

## セルフチェック

- [x] CI が通っている
- [x] `console.log` などのデバッグコードを削除した
- [x] シークレットがハードコードされていない

## 仕様からの逸脱

なし