### PR TITLE
[UI] スマホ向けレスポンシブ対応

### DIFF
--- a/src/app/(main)/companies/[slug]/page.tsx
+++ b/src/app/(main)/companies/[slug]/page.tsx
@@ -89,7 +89,7 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
   }
 
   return (
-    <main className="mx-auto max-w-2xl px-6 py-8">
+    <main className="mx-auto max-w-2xl px-4 py-6 md:px-6 md:py-8">
       {/* Back link */}
       <Link
         href="/discover"
@@ -99,7 +99,7 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
       </Link>
 
       {/* Company header card */}
-      <section className="border-sg-line bg-sg-surface mb-6 flex items-center gap-4 rounded-2xl border p-6">
+      <section className="border-sg-line bg-sg-surface mb-6 flex items-center gap-3 rounded-2xl border p-4 md:gap-4 md:p-6">
         <CompanyLogo
           name={company.name}
           logoUrl={company.logoUrl}
@@ -125,12 +125,12 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
       </section>
 
       {/* Tab filters */}
-      <div className="mb-5 flex gap-2">
+      <div className="mb-5 flex gap-2 overflow-x-auto pb-0.5">
         {tabs.map((tab) => (
           <Link
             key={tab.value}
             href={tabHref(tab.value)}
-            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+            className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
               type === tab.value
                 ? 'bg-sg-accent-soft text-sg-accent-deep font-semibold'
                 : 'border-sg-line bg-sg-surface text-sg-ink-soft hover:bg-sg-line-soft border'

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -41,8 +41,8 @@ export default async function DiscoverPage({ searchParams }: PageProps) {
   const followedSet = new Set(followedRows.map((f) => f.companyId))
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-8">
-      <h1 className="text-sg-ink mb-1 text-2xl font-black">企業を探す</h1>
+    <main className="mx-auto max-w-4xl px-4 py-6 md:px-6 md:py-8">
+      <h1 className="text-sg-ink mb-1 text-xl font-black md:text-2xl">企業を探す</h1>
       <p className="text-sg-ink-soft mb-6 text-sm">
         気になる企業をフォローしてフィードをカスタマイズしよう
       </p>

--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -100,32 +100,35 @@ export default async function FeedPage({ searchParams }: PageProps) {
   }
 
   return (
-    <main className="mx-auto max-w-2xl px-6 py-8">
-      <h1 className="text-sg-ink mb-1 text-2xl font-black">フィード</h1>
+    <main className="mx-auto max-w-2xl px-4 py-6 md:px-6 md:py-8">
+      <h1 className="text-sg-ink mb-1 text-xl font-black md:text-2xl">フィード</h1>
       {userId && (
         <p className="text-sg-ink-soft mb-5 text-sm">
           {following ? 'フォロー中の企業の最新情報' : 'すべての企業の最新情報'}
         </p>
       )}
 
-      {/* Type filter chips */}
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        {feedTabs.map((tab) => (
-          <Link
-            key={tab.value}
-            href={tabHref(tab.value)}
-            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
-              type === tab.value
-                ? 'bg-sg-accent-soft text-sg-accent-deep font-semibold'
-                : 'border-sg-line bg-sg-surface text-sg-ink-soft hover:bg-sg-line-soft border'
-            }`}
-          >
-            {tab.label}
-          </Link>
-        ))}
+      {/* Filters */}
+      <div className="mb-4 flex flex-col gap-2">
+        {/* Type filter chips */}
+        <div className="flex gap-2 overflow-x-auto pb-0.5">
+          {feedTabs.map((tab) => (
+            <Link
+              key={tab.value}
+              href={tabHref(tab.value)}
+              className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                type === tab.value
+                  ? 'bg-sg-accent-soft text-sg-accent-deep font-semibold'
+                  : 'border-sg-line bg-sg-surface text-sg-ink-soft hover:bg-sg-line-soft border'
+              }`}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </div>
         {/* Following toggle */}
         {userId && (
-          <div className="ml-auto flex gap-1">
+          <div className="flex justify-end gap-1">
             <Link
               href={`/feed?${new URLSearchParams({ ...(type !== 'all' ? { type } : {}) })}`}
               className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@/lib/auth'
+import { BottomNav } from '@/components/BottomNav'
 import { Sidebar } from '@/components/Sidebar'
 import { TopBar } from '@/components/TopBar'
 
@@ -9,8 +10,9 @@ export default async function MainLayout({ children }: { children: React.ReactNo
       <TopBar session={session} />
       <div className="flex min-h-0 flex-1">
         <Sidebar session={session} />
-        <div className="flex-1 overflow-auto">{children}</div>
+        <div className="flex-1 overflow-auto pb-16 md:pb-0">{children}</div>
       </div>
+      <BottomNav />
     </div>
   )
 }

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -31,9 +31,9 @@ export default async function MyPage() {
   const initial = (user.name ?? user.email ?? '?')[0].toUpperCase()
 
   return (
-    <main className="mx-auto max-w-2xl px-6 py-8">
+    <main className="mx-auto max-w-2xl px-4 py-6 md:px-6 md:py-8">
       {/* Profile card */}
-      <section className="border-sg-line bg-sg-surface mb-6 flex items-center gap-4 rounded-2xl border p-6">
+      <section className="border-sg-line bg-sg-surface mb-6 flex items-center gap-3 rounded-2xl border p-4 md:gap-4 md:p-6">
         <div className="bg-sg-accent flex h-16 w-16 shrink-0 items-center justify-center rounded-full text-2xl font-black text-white">
           {initial}
         </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const items = [
+  {
+    href: '/feed',
+    label: 'フィード',
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <line x1="8" y1="6" x2="21" y2="6" />
+        <line x1="8" y1="12" x2="21" y2="12" />
+        <line x1="8" y1="18" x2="21" y2="18" />
+        <line x1="3" y1="6" x2="3.01" y2="6" />
+        <line x1="3" y1="12" x2="3.01" y2="12" />
+        <line x1="3" y1="18" x2="3.01" y2="18" />
+      </svg>
+    ),
+  },
+  {
+    href: '/discover',
+    label: '企業を探す',
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+    ),
+  },
+  {
+    href: '/mypage',
+    label: 'マイページ',
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    ),
+  },
+]
+
+export function BottomNav() {
+  const pathname = usePathname()
+  return (
+    <nav className="border-sg-line-soft bg-sg-surface fixed right-0 bottom-0 left-0 z-50 flex border-t md:hidden">
+      {items.map(({ href, label, icon }) => {
+        const isActive = pathname === href || pathname.startsWith(href + '/')
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex flex-1 flex-col items-center gap-0.5 py-2 text-[10px] font-medium transition-colors ${
+              isActive ? 'text-sg-accent-deep' : 'text-sg-ink-faint'
+            }`}
+          >
+            {icon}
+            {label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function Sidebar({ session }: Props) {
   const user = session?.user
   return (
-    <aside className="border-sg-line-soft bg-sg-surface flex w-[200px] shrink-0 flex-col border-r">
+    <aside className="border-sg-line-soft bg-sg-surface hidden w-[200px] shrink-0 flex-col border-r md:flex">
       <div className="text-sg-ink-faint px-4 pt-4 pb-2 text-[11px] font-semibold tracking-wider uppercase">
         メニュー
       </div>


### PR DESCRIPTION
## 関連 Issue

Closes #46

## 変更内容

### P0: サイドバー問題を解消
- `Sidebar.tsx`: `hidden md:flex` — モバイル(md未満)で非表示
- `BottomNav.tsx` 新規作成 — モバイル専用ボトムナビゲーション（フィード / 企業を探す / マイページ）
- `layout.tsx`: BottomNav を追加、メインコンテンツに `pb-16 md:pb-0`（BottomNavと重ならないよう）

### P1: パディング・タブフィルター
- 全ページ（feed / discover / mypage / companies/[slug]）: `px-6 → px-4 md:px-6`、`py-8 → py-6 md:py-8`
- `feed/page.tsx`: タブフィルター行を type chips と following toggle の2行に分離。type chips は `overflow-x-auto` で横スクロール対応
- `companies/[slug]/page.tsx`: タブフィルターに `overflow-x-auto` + `shrink-0`

### P2: テキスト・カード余白
- h1: `text-2xl → text-xl md:text-2xl`
- mypage プロフィールカード・companies ヘッダーカード: `gap-4 → gap-3 md:gap-4`、`p-6 → p-4 md:p-6`

## テスト方法

1. Chrome DevTools でモバイルビュー(375px)に切り替え
2. `/feed`, `/discover`, `/mypage`, `/companies/[slug]` を順に確認
3. 画面下部にボトムナビが表示されること
4. サイドバーが非表示になっていること
5. タブフィルターが1行に収まること（または横スクロールできること）
6. デスクトップ幅ではサイドバーが表示され、ボトムナビが非表示であること

## セルフチェック

- [x] CI が通っている
- [x] TypeScript / ESLint / Prettier / Build 確認済み

## 仕様からの逸脱

なし