### PR TITLE
[fix] クローラー: PR TIMES (RDF形式) の日付パース修正

### DIFF
--- a/crawler/fetch.ts
+++ b/crawler/fetch.ts
@@ -16,12 +16,10 @@ export interface FeedItem {
 export async function fetchRssFeed(feedUrl: string): Promise<FeedItem[]> {
   const feed = await parser.parseURL(feedUrl)
   return feed.items
-    .filter((item): item is Parser.Item & { title: string; link: string; pubDate: string } =>
-      Boolean(item.title && item.link && item.pubDate),
-    )
+    .filter((item) => Boolean(item.title && item.link && (item.pubDate ?? item.isoDate)))
     .map((item) => ({
-      title: item.title,
-      link: item.link,
-      pubDate: item.pubDate,
+      title: item.title!,
+      link: item.link!,
+      pubDate: (item.pubDate ?? item.isoDate)!,
     }))
 }


### PR DESCRIPTION
## 原因

RSS 1.0 (RDF) 形式では日付フィールドが `pubDate` でなく `dc:date` で配信される。
`rss-parser` はこれを `isoDate` にマッピングするが、`fetch.ts` が `pubDate` のみを参照していたため、PR TIMES の全アイテムがフィルターで除外されてい た。

結果: プレスリリース記事が 0 件のままになっていた。

## 修正

`item.pubDate ?? item.isoDate` にフォールバックするよう変更。

## 確認

修正後にローカルでクロールを実行し、5,325 件の新規プレスリリース記事が取得・保存された。