### PR TITLE
[fix] フィードタブ切り替え時に記事リストをリセット

### DIFF
--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -170,6 +170,7 @@ export default async function FeedPage({ searchParams }: PageProps) {
       ) : (
         <Suspense>
           <FeedInfiniteScroll
+            key={`${type}-${following}`}
             initialArticles={initialArticles}
             initialNextCursor={initialNextCursor}
             type={type}


### PR DESCRIPTION
## 原因

`FeedInfiniteScroll` は `useState(initialArticles)` で記事を管理している。
タブを切り替えるとURLが変わりサーバー側では新しい記事を取得するが、
クライアントコンポーネントのインスタンスが再利用されるため state がリセットされず、
前のタブの記事が残り続けていた。

## 修正

`FeedInfiniteScroll` に `key={\`${type}-${following}\`}` を追加。
タブや following が変わると key が変わり React がコンポーネントを再マウントする。