### PR TITLE
fix(company) + feat(infra): モバイル企業一覧UI修正 & SEO対策

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ AUTH_GITHUB_SECRET=
 
 # App URL (本番: https://signalog.vercel.app)
 AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # Sentry (Phase 1: オプション)
 # NEXT_PUBLIC_SENTRY_DSN=

--- a/src/app/(main)/companies/[slug]/page.tsx
+++ b/src/app/(main)/companies/[slug]/page.tsx
@@ -20,8 +20,26 @@ type FeedType = 'tech' | 'press' | 'all'
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params
   const [company] = await db.select().from(companies).where(eq(companies.slug, slug)).limit(1)
-  if (!company) return { title: '企業が見つかりません | Signalog' }
-  return { title: `${company.name} | Signalog` }
+  if (!company) return { title: '企業が見つかりません' }
+
+  const description = company.description
+    ? `${company.description} — テックブログとプレスリリースをまとめてチェック`
+    : `${company.name}のテックブログとプレスリリースをチェックしよう`
+
+  return {
+    title: company.name,
+    description,
+    openGraph: {
+      title: `${company.name} | Signalog`,
+      description,
+      images: company.logoUrl ? [{ url: company.logoUrl }] : [],
+    },
+    twitter: {
+      card: 'summary' as const,
+      title: `${company.name} | Signalog`,
+      description,
+    },
+  }
 }
 
 export default async function CompanyPage({ params, searchParams }: PageProps) {

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -63,7 +63,7 @@ export default async function DiscoverPage({ searchParams }: PageProps) {
             {companyList.map((company) => (
               <li
                 key={company.id}
-                className="border-sg-line bg-sg-surface flex items-center gap-3 rounded-2xl border p-4 transition-shadow hover:shadow-sm"
+                className="border-sg-line bg-sg-surface flex min-w-0 items-center gap-3 rounded-2xl border p-4 transition-shadow hover:shadow-sm"
               >
                 <CompanyLogo
                   name={company.name}

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -13,7 +13,14 @@ interface PageProps {
   searchParams: Promise<{ q?: string }>
 }
 
-export const metadata = { title: '企業を探す | Signalog' }
+export const metadata = {
+  title: '企業を探す',
+  description: '気になる企業をフォローして、テックブログとプレスリリースをまとめてチェックしよう',
+  openGraph: {
+    title: '企業を探す | Signalog',
+    description: '気になる企業をフォローして、テックブログとプレスリリースをまとめてチェックしよう',
+  },
+}
 
 export default async function DiscoverPage({ searchParams }: PageProps) {
   const { q } = await searchParams

--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -9,7 +9,14 @@ import { articles, companies, follows } from '../../../../db/schema'
 import type { ArticleWithCompany } from '@/app/api/feed/route'
 import { FeedInfiniteScroll } from './FeedInfiniteScroll'
 
-export const metadata = { title: 'フィード | Signalog' }
+export const metadata = {
+  title: 'フィード',
+  description: 'フォロー中の企業の最新テックブログとプレスリリースをチェックしよう',
+  openGraph: {
+    title: 'フィード | Signalog',
+    description: 'フォロー中の企業の最新テックブログとプレスリリースをチェックしよう',
+  },
+}
 
 const LIMIT = 20
 

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -7,7 +7,11 @@ import { db } from '@/lib/db/server'
 import { companies, follows } from '../../../../db/schema'
 import { FollowedCompaniesList } from './FollowedCompaniesList'
 
-export const metadata = { title: 'マイページ | Signalog' }
+export const metadata = {
+  title: 'マイページ',
+  description: 'フォロー中の企業を管理しよう',
+  robots: { index: false },
+}
 
 export default async function MyPage() {
   const session = await auth()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,9 +11,28 @@ const zenMaruGothic = Zen_Maru_Gothic({
   variable: '--font-zen',
 })
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://signalog.vercel.app'
+const DESCRIPTION = '企業のテックブログとプレスリリースを一元的にフォローできるプラットフォーム'
+
 export const metadata: Metadata = {
-  title: 'Signalog',
-  description: '企業のテックブログとプレスリリースを一元的にフォローできるプラットフォーム',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: 'Signalog',
+    template: '%s | Signalog',
+  },
+  description: DESCRIPTION,
+  openGraph: {
+    type: 'website',
+    siteName: 'Signalog',
+    title: 'Signalog',
+    description: DESCRIPTION,
+    url: SITE_URL,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Signalog',
+    description: DESCRIPTION,
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://signalog.vercel.app'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/login'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,9 @@ import { companies } from '../../db/schema'
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://signalog.vercel.app'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const companyList = await db.select({ slug: companies.slug, updatedAt: companies.updatedAt }).from(companies)
+  const companyList = await db
+    .select({ slug: companies.slug, updatedAt: companies.updatedAt })
+    .from(companies)
 
   const staticPages: MetadataRoute.Sitemap = [
     {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next'
+
+import { db } from '@/lib/db/server'
+import { companies } from '../../db/schema'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://signalog.vercel.app'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const companyList = await db.select({ slug: companies.slug, updatedAt: companies.updatedAt }).from(companies)
+
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/discover`,
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+  ]
+
+  const companyPages: MetadataRoute.Sitemap = companyList.map((c) => ({
+    url: `${SITE_URL}/companies/${c.slug}`,
+    lastModified: c.updatedAt,
+    changeFrequency: 'daily',
+    priority: 0.8,
+  }))
+
+  return [...staticPages, ...companyPages]
+}


### PR DESCRIPTION
## Summary

- スマホ版「企業を探す」のカードUI崩れを2点修正
- SEO基盤（robots.txt・sitemap・OGPメタデータ）を追加（Closes #56, #57, #58）

## 変更内容

### fix: モバイル企業一覧カードのUI崩れ

- `li`（グリッドアイテム）に `min-w-0` がなく、会社名の幅までカードが拡張されフォローボタンが画面外にはみ出ていた → `min-w-0` を追加
- `Link`（inline要素）の `truncate` が効かなかった → `block` 追加 + 親に `overflow-hidden`

### feat: SEO対策

| 対応 | 内容 |
|------|------|
| `src/app/robots.ts` | `/api/`・`/login` を Disallow、sitemap URL を明記 |
| `src/app/sitemap.ts` | `/discover` + 全企業ページを動的生成 |
| `layout.tsx` | `metadataBase`・`title template`・OGP・Twitter Card を設定 |
| 各ページ | description + openGraph 追加、マイページは `noindex` |
| 企業詳細ページ | `generateMetadata` に description・OGP画像・Twitter Card を追加 |

## Test plan

- [x] スマホ実機で `/discover` のカードがはみ出ていないことを確認
- [ ] `/robots.txt`・`/sitemap.xml` が正しく返ることを確認
- [ ] OGP デバッガーで各ページのプレビューを確認
- [ ] Vercel に `NEXT_PUBLIC_SITE_URL` 環境変数を設定する

---

補足: バグ修正9件・クローラー復旧はマージ後の追加作業として #79 に分離しました。