### PR TITLE
[SGL-P2C] ブックマーク機能 + 人気記事ページ

### DIFF
--- a/db/migrations/0001_steep_electro.sql
+++ b/db/migrations/0001_steep_electro.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "bookmarks" (
+	"user_id" uuid NOT NULL,
+	"article_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "bookmarks_user_id_article_id_pk" PRIMARY KEY("user_id","article_id")
+);
+--> statement-breakpoint
+ALTER TABLE "articles" ADD COLUMN "bookmark_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_article_id_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."articles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bookmarks_article_idx" ON "bookmarks" USING btree ("article_id");--> statement-breakpoint
+CREATE INDEX "articles_bookmark_count_idx" ON "articles" USING btree ("bookmark_count");

--- a/db/migrations/meta/0001_snapshot.json
+++ b/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,723 @@
+{
+  "id": "8d4640cd-ae4d-4a4d-8829-5b315c902374",
+  "prevId": "f430379f-ea9b-4c92-8c00-d12f1406b03b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_type": {
+          "name": "feed_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ogp_image_url": {
+          "name": "ogp_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary_generated_at": {
+          "name": "ai_summary_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "articles_company_url_idx": {
+          "name": "articles_company_url_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_pub_id_idx": {
+          "name": "articles_pub_id_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "articles_bookmark_count_idx": {
+          "name": "articles_bookmark_count_idx",
+          "columns": [
+            {
+              "expression": "bookmark_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "articles_company_id_companies_id_fk": {
+          "name": "articles_company_id_companies_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_article_idx": {
+          "name": "bookmarks_article_idx",
+          "columns": [
+            {
+              "expression": "article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_article_id_articles_id_fk": {
+          "name": "bookmarks_article_id_articles_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_user_id_article_id_pk": {
+          "name": "bookmarks_user_id_article_id_pk",
+          "columns": [
+            "user_id",
+            "article_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_slug_unique": {
+          "name": "companies_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_feeds": {
+      "name": "company_feeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feed_type": {
+          "name": "feed_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_feeds_company_id_companies_id_fk": {
+          "name": "company_feeds_company_id_companies_id_fk",
+          "tableFrom": "company_feeds",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_user_id_users_id_fk": {
+          "name": "follows_user_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_company_id_companies_id_fk": {
+          "name": "follows_company_id_companies_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_user_id_company_id_pk": {
+          "name": "follows_user_id_company_id_pk",
+          "columns": [
+            "user_id",
+            "company_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777165002188,
       "tag": "0000_brown_human_torch",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777858869383,
+      "tag": "0001_steep_electro",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -134,12 +134,35 @@ export const articles = pgTable(
     ogpImageUrl: text('ogp_image_url'),
     publishedAt: timestamp('published_at', { withTimezone: true }).notNull(),
     fetchedAt: timestamp('fetched_at', { withTimezone: true }).notNull().defaultNow(),
-    aiSummary: text('ai_summary'), // Phase 2 用に予約
-    aiSummaryGeneratedAt: timestamp('ai_summary_generated_at', { withTimezone: true }), // Phase 2 用に予約
+    bookmarkCount: integer('bookmark_count').notNull().default(0),
+    aiSummary: text('ai_summary'),
+    aiSummaryGeneratedAt: timestamp('ai_summary_generated_at', { withTimezone: true }),
   },
   (table) => ({
     companyUrlIdx: uniqueIndex('articles_company_url_idx').on(table.companyId, table.normalizedUrl),
     pubIdIdx: index('articles_pub_id_idx').on(table.publishedAt, table.id),
+    bookmarkCountIdx: index('articles_bookmark_count_idx').on(table.bookmarkCount),
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// ブックマーク
+// ---------------------------------------------------------------------------
+
+export const bookmarks = pgTable(
+  'bookmarks',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    articleId: uuid('article_id')
+      .notNull()
+      .references(() => articles.id, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.articleId] }),
+    articleIdx: index('bookmarks_article_idx').on(table.articleId),
   }),
 )
 
@@ -151,6 +174,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),
   follows: many(follows),
+  bookmarks: many(bookmarks),
 }))
 
 export const accountsRelations = relations(accounts, ({ one }) => ({
@@ -176,6 +200,12 @@ export const followsRelations = relations(follows, ({ one }) => ({
   company: one(companies, { fields: [follows.companyId], references: [companies.id] }),
 }))
 
-export const articlesRelations = relations(articles, ({ one }) => ({
+export const articlesRelations = relations(articles, ({ one, many }) => ({
   company: one(companies, { fields: [articles.companyId], references: [companies.id] }),
+  bookmarks: many(bookmarks),
+}))
+
+export const bookmarksRelations = relations(bookmarks, ({ one }) => ({
+  user: one(users, { fields: [bookmarks.userId], references: [users.id] }),
+  article: one(articles, { fields: [bookmarks.articleId], references: [articles.id] }),
 }))

--- a/src/app/(main)/bookmarks/page.tsx
+++ b/src/app/(main)/bookmarks/page.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { desc, eq } from 'drizzle-orm'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { ArticleCard } from '@/components/ArticleCard'
+import { articles, bookmarks, companies } from '../../../../db/schema'
+import type { ArticleWithCompany } from '@/app/api/feed/route'
+
+export const metadata = {
+  title: 'ブックマーク',
+  description: 'ブックマークした記事一覧',
+}
+
+export default async function BookmarksPage() {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login')
+
+  const userId = session.user.id
+
+  const rows = await db
+    .select({
+      id: articles.id,
+      title: articles.title,
+      sourceUrl: articles.sourceUrl,
+      ogpImageUrl: articles.ogpImageUrl,
+      publishedAt: articles.publishedAt,
+      feedType: articles.feedType,
+      aiSummary: articles.aiSummary,
+      bookmarkCount: articles.bookmarkCount,
+      companyId: companies.id,
+      companyName: companies.name,
+      companySlug: companies.slug,
+      companyLogoUrl: companies.logoUrl,
+    })
+    .from(bookmarks)
+    .innerJoin(articles, eq(bookmarks.articleId, articles.id))
+    .innerJoin(companies, eq(articles.companyId, companies.id))
+    .where(eq(bookmarks.userId, userId))
+    .orderBy(desc(bookmarks.createdAt))
+    .limit(100)
+
+  const savedArticles: ArticleWithCompany[] = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    sourceUrl: row.sourceUrl,
+    ogpImageUrl: row.ogpImageUrl,
+    publishedAt: row.publishedAt.toISOString(),
+    feedType: row.feedType,
+    aiSummary: row.aiSummary,
+    bookmarkCount: row.bookmarkCount,
+    isBookmarked: true,
+    company: {
+      id: row.companyId,
+      name: row.companyName,
+      slug: row.companySlug,
+      logoUrl: row.companyLogoUrl,
+    },
+  }))
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-6 md:px-6 md:py-8">
+      <h1 className="text-sg-ink mb-1 text-xl font-black md:text-2xl">ブックマーク</h1>
+      <p className="text-sg-ink-soft mb-6 text-sm">保存した記事 {savedArticles.length}件</p>
+
+      {savedArticles.length === 0 ? (
+        <div className="border-sg-line bg-sg-surface rounded-2xl border py-20 text-center">
+          <p className="text-sg-ink-soft mb-3">ブックマークした記事がありません</p>
+          <Link
+            href="/feed"
+            className="bg-sg-accent hover:bg-sg-accent-deep inline-flex items-center gap-1 rounded-full px-5 py-2 text-sm font-semibold text-white"
+          >
+            フィードを見る →
+          </Link>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {savedArticles.map((article) => (
+            <ArticleCard key={article.id} article={article} />
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/(main)/companies/[slug]/page.tsx
+++ b/src/app/(main)/companies/[slug]/page.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { desc, eq, and } from 'drizzle-orm'
+import { desc, eq, and, inArray } from 'drizzle-orm'
 
 import { CompanyLogo } from '@/components/CompanyLogo'
 import { FollowButton } from '@/components/FollowButton'
 import { ArticleCard } from '@/components/ArticleCard'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db/server'
-import { articles, companies, follows } from '../../../../../db/schema'
+import { articles, bookmarks, companies, follows } from '../../../../../db/schema'
 import type { ArticleWithCompany } from '@/app/api/feed/route'
 
 interface PageProps {
@@ -63,6 +63,7 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
         publishedAt: articles.publishedAt,
         feedType: articles.feedType,
         aiSummary: articles.aiSummary,
+        bookmarkCount: articles.bookmarkCount,
       })
       .from(articles)
       .where(
@@ -82,6 +83,23 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
 
   const isFollowed = followedRows.length > 0
 
+  let bookmarkedIds = new Set<string>()
+  if (userId && articleRows.length > 0) {
+    const bRows = await db
+      .select({ articleId: bookmarks.articleId })
+      .from(bookmarks)
+      .where(
+        and(
+          eq(bookmarks.userId, userId),
+          inArray(
+            bookmarks.articleId,
+            articleRows.map((a) => a.id),
+          ),
+        ),
+      )
+    bookmarkedIds = new Set(bRows.map((r) => r.articleId))
+  }
+
   const companyArticles: ArticleWithCompany[] = articleRows.map((a) => ({
     id: a.id,
     title: a.title,
@@ -90,6 +108,8 @@ export default async function CompanyPage({ params, searchParams }: PageProps) {
     publishedAt: a.publishedAt.toISOString(),
     feedType: a.feedType,
     aiSummary: a.aiSummary,
+    bookmarkCount: a.bookmarkCount,
+    isBookmarked: bookmarkedIds.has(a.id),
     company: {
       id: company.id,
       name: company.name,

--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -5,7 +5,7 @@ import { auth } from '@/lib/auth'
 import { encodeCursor } from '@/lib/cursor'
 import { db } from '@/lib/db/server'
 import { and, desc, eq, inArray } from 'drizzle-orm'
-import { articles, companies, follows } from '../../../../db/schema'
+import { articles, bookmarks, companies, follows } from '../../../../db/schema'
 import type { ArticleWithCompany } from '@/app/api/feed/route'
 import { FeedInfiniteScroll } from './FeedInfiniteScroll'
 
@@ -63,6 +63,7 @@ export default async function FeedPage({ searchParams }: PageProps) {
             publishedAt: articles.publishedAt,
             feedType: articles.feedType,
             aiSummary: articles.aiSummary,
+            bookmarkCount: articles.bookmarkCount,
             companyId: companies.id,
             companyName: companies.name,
             companySlug: companies.slug,
@@ -75,7 +76,26 @@ export default async function FeedPage({ searchParams }: PageProps) {
           .limit(LIMIT + 1)
 
   const hasMore = rows.length > LIMIT
-  const initialArticles: ArticleWithCompany[] = rows.slice(0, LIMIT).map((row) => ({
+  const pageRows = rows.slice(0, LIMIT)
+
+  let bookmarkedIds = new Set<string>()
+  if (userId && pageRows.length > 0) {
+    const bRows = await db
+      .select({ articleId: bookmarks.articleId })
+      .from(bookmarks)
+      .where(
+        and(
+          eq(bookmarks.userId, userId),
+          inArray(
+            bookmarks.articleId,
+            pageRows.map((r) => r.id),
+          ),
+        ),
+      )
+    bookmarkedIds = new Set(bRows.map((r) => r.articleId))
+  }
+
+  const initialArticles: ArticleWithCompany[] = pageRows.map((row) => ({
     id: row.id,
     title: row.title,
     sourceUrl: row.sourceUrl,
@@ -83,6 +103,8 @@ export default async function FeedPage({ searchParams }: PageProps) {
     publishedAt: row.publishedAt.toISOString(),
     feedType: row.feedType,
     aiSummary: row.aiSummary,
+    bookmarkCount: row.bookmarkCount,
+    isBookmarked: bookmarkedIds.has(row.id),
     company: {
       id: row.companyId,
       name: row.companyName,

--- a/src/app/(main)/popular/page.tsx
+++ b/src/app/(main)/popular/page.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'
+import { and, desc, eq, gte, inArray } from 'drizzle-orm'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { ArticleCard } from '@/components/ArticleCard'
+import { articles, bookmarks, companies } from '../../../../db/schema'
+import type { ArticleWithCompany } from '@/app/api/feed/route'
+
+export const metadata = {
+  title: '人気記事',
+  description: '直近30日間でブックマークが多い人気記事',
+}
+
+type FeedType = 'tech' | 'press' | 'all'
+
+interface PageProps {
+  searchParams: Promise<{ type?: string }>
+}
+
+const RECENCY_DAYS = 30
+
+export default async function PopularPage({ searchParams }: PageProps) {
+  const { type: typeParam } = await searchParams
+  const type: FeedType = typeParam === 'tech' || typeParam === 'press' ? typeParam : 'all'
+
+  const session = await auth()
+  const userId = session?.user?.id ?? null
+
+  // eslint-disable-next-line react-hooks/purity -- Server Component では Date.now() は安全
+  const since = new Date(Date.now() - RECENCY_DAYS * 24 * 60 * 60 * 1000)
+
+  const conditions = [gte(articles.publishedAt, since)]
+  if (type !== 'all') {
+    conditions.push(eq(articles.feedType, type))
+  }
+
+  const rows = await db
+    .select({
+      id: articles.id,
+      title: articles.title,
+      sourceUrl: articles.sourceUrl,
+      ogpImageUrl: articles.ogpImageUrl,
+      publishedAt: articles.publishedAt,
+      feedType: articles.feedType,
+      aiSummary: articles.aiSummary,
+      bookmarkCount: articles.bookmarkCount,
+      companyId: companies.id,
+      companyName: companies.name,
+      companySlug: companies.slug,
+      companyLogoUrl: companies.logoUrl,
+    })
+    .from(articles)
+    .innerJoin(companies, eq(articles.companyId, companies.id))
+    .where(and(...conditions))
+    .orderBy(desc(articles.bookmarkCount), desc(articles.publishedAt))
+    .limit(30)
+
+  let bookmarkedIds = new Set<string>()
+  if (userId && rows.length > 0) {
+    const bRows = await db
+      .select({ articleId: bookmarks.articleId })
+      .from(bookmarks)
+      .where(
+        and(
+          eq(bookmarks.userId, userId),
+          inArray(
+            bookmarks.articleId,
+            rows.map((r) => r.id),
+          ),
+        ),
+      )
+    bookmarkedIds = new Set(bRows.map((r) => r.articleId))
+  }
+
+  const popularArticles: ArticleWithCompany[] = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    sourceUrl: row.sourceUrl,
+    ogpImageUrl: row.ogpImageUrl,
+    publishedAt: row.publishedAt.toISOString(),
+    feedType: row.feedType,
+    aiSummary: row.aiSummary,
+    bookmarkCount: row.bookmarkCount,
+    isBookmarked: bookmarkedIds.has(row.id),
+    company: {
+      id: row.companyId,
+      name: row.companyName,
+      slug: row.companySlug,
+      logoUrl: row.companyLogoUrl,
+    },
+  }))
+
+  const tabs: { label: string; value: FeedType }[] = [
+    { label: 'すべて', value: 'all' },
+    { label: 'Tech Blog', value: 'tech' },
+    { label: 'プレスリリース', value: 'press' },
+  ]
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-6 md:px-6 md:py-8">
+      <h1 className="text-sg-ink mb-1 text-xl font-black md:text-2xl">人気記事</h1>
+      <p className="text-sg-ink-soft mb-5 text-sm">直近30日間でブックマークが多い記事</p>
+
+      <div className="mb-4 flex gap-2 overflow-x-auto pb-0.5">
+        {tabs.map((tab) => {
+          const href = tab.value === 'all' ? '/popular' : `/popular?type=${tab.value}`
+          return (
+            <Link
+              key={tab.value}
+              href={href}
+              className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                type === tab.value
+                  ? 'bg-sg-accent-soft text-sg-accent-deep font-semibold'
+                  : 'border-sg-line bg-sg-surface text-sg-ink-soft hover:bg-sg-line-soft border'
+              }`}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </div>
+
+      {popularArticles.length === 0 ? (
+        <div className="border-sg-line bg-sg-surface rounded-2xl border py-20 text-center">
+          <p className="text-sg-ink-soft">まだブックマークされた記事がありません</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {popularArticles.map((article, i) => (
+            <div key={article.id} className="flex items-start gap-3">
+              <span className="text-sg-ink-faint mt-5 w-6 shrink-0 text-center text-xs font-bold">
+                {i + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <ArticleCard article={article} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/api/articles/popular/route.ts
+++ b/src/app/api/articles/popular/route.ts
@@ -1,0 +1,84 @@
+import { and, desc, eq, gte, inArray } from 'drizzle-orm'
+import { type NextRequest } from 'next/server'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { articles, bookmarks, companies } from '../../../../../db/schema'
+import type { ArticleWithCompany } from '@/app/api/feed/route'
+
+const LIMIT = 20
+// 30日以内の記事を対象にする
+const RECENCY_DAYS = 30
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const type = searchParams.get('type') as 'tech' | 'press' | null
+
+  const session = await auth()
+  const userId = session?.user?.id ?? null
+
+  const since = new Date(Date.now() - RECENCY_DAYS * 24 * 60 * 60 * 1000)
+
+  const conditions = [gte(articles.publishedAt, since)]
+  if (type === 'tech' || type === 'press') {
+    conditions.push(eq(articles.feedType, type))
+  }
+
+  const rows = await db
+    .select({
+      id: articles.id,
+      title: articles.title,
+      sourceUrl: articles.sourceUrl,
+      ogpImageUrl: articles.ogpImageUrl,
+      publishedAt: articles.publishedAt,
+      feedType: articles.feedType,
+      aiSummary: articles.aiSummary,
+      bookmarkCount: articles.bookmarkCount,
+      companyId: companies.id,
+      companyName: companies.name,
+      companySlug: companies.slug,
+      companyLogoUrl: companies.logoUrl,
+    })
+    .from(articles)
+    .innerJoin(companies, eq(articles.companyId, companies.id))
+    .where(and(...conditions))
+    .orderBy(desc(articles.bookmarkCount), desc(articles.publishedAt))
+    .limit(LIMIT)
+
+  let bookmarkedIds = new Set<string>()
+  if (userId && rows.length > 0) {
+    const bRows = await db
+      .select({ articleId: bookmarks.articleId })
+      .from(bookmarks)
+      .where(
+        and(
+          eq(bookmarks.userId, userId),
+          inArray(
+            bookmarks.articleId,
+            rows.map((r) => r.id),
+          ),
+        ),
+      )
+    bookmarkedIds = new Set(bRows.map((r) => r.articleId))
+  }
+
+  const result: ArticleWithCompany[] = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    sourceUrl: row.sourceUrl,
+    ogpImageUrl: row.ogpImageUrl,
+    publishedAt: row.publishedAt.toISOString(),
+    feedType: row.feedType,
+    aiSummary: row.aiSummary,
+    bookmarkCount: row.bookmarkCount,
+    isBookmarked: bookmarkedIds.has(row.id),
+    company: {
+      id: row.companyId,
+      name: row.companyName,
+      slug: row.companySlug,
+      logoUrl: row.companyLogoUrl,
+    },
+  }))
+
+  return Response.json({ data: result })
+}

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -1,0 +1,87 @@
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { type NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db/server'
+import { articles, bookmarks } from '../../../../db/schema'
+
+const toggleSchema = z.object({ articleId: z.string().uuid() })
+
+export async function POST(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return Response.json(
+      { error: { code: 'UNAUTHORIZED', message: 'ログインが必要です' } },
+      { status: 401 },
+    )
+  }
+
+  const body = await request.json().catch(() => null)
+  const parsed = toggleSchema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json(
+      { error: { code: 'BAD_REQUEST', message: '不正なリクエストです' } },
+      { status: 400 },
+    )
+  }
+
+  const { articleId } = parsed.data
+  const userId = session.user.id
+
+  const [existing] = await db
+    .select({ userId: bookmarks.userId })
+    .from(bookmarks)
+    .where(and(eq(bookmarks.userId, userId), eq(bookmarks.articleId, articleId)))
+    .limit(1)
+
+  if (existing) {
+    await db
+      .delete(bookmarks)
+      .where(and(eq(bookmarks.userId, userId), eq(bookmarks.articleId, articleId)))
+    await db
+      .update(articles)
+      .set({ bookmarkCount: sql`GREATEST(bookmark_count - 1, 0)` })
+      .where(eq(articles.id, articleId))
+    return Response.json({ bookmarked: false })
+  } else {
+    await db.insert(bookmarks).values({ userId, articleId })
+    await db
+      .update(articles)
+      .set({ bookmarkCount: sql`bookmark_count + 1` })
+      .where(eq(articles.id, articleId))
+    return Response.json({ bookmarked: true })
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return Response.json(
+      { error: { code: 'UNAUTHORIZED', message: 'ログインが必要です' } },
+      { status: 401 },
+    )
+  }
+
+  const { searchParams } = request.nextUrl
+  const articleIdsParam = searchParams.get('articleIds')
+  if (!articleIdsParam) {
+    return Response.json({ bookmarkedIds: [] })
+  }
+
+  const ids = articleIdsParam
+    .split(',')
+    .filter((id) => /^[0-9a-f-]{36}$/.test(id))
+    .slice(0, 50)
+
+  if (ids.length === 0) {
+    return Response.json({ bookmarkedIds: [] })
+  }
+
+  const rows = await db
+    .select({ articleId: bookmarks.articleId })
+    .from(bookmarks)
+    .where(and(eq(bookmarks.userId, session.user.id), inArray(bookmarks.articleId, ids)))
+
+  return Response.json({ bookmarkedIds: rows.map((r) => r.articleId) })
+}

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -4,7 +4,7 @@ import { type NextRequest } from 'next/server'
 import { auth } from '@/lib/auth'
 import { decodeCursor, encodeCursor } from '@/lib/cursor'
 import { db } from '@/lib/db/server'
-import { articles, companies, follows } from '../../../../db/schema'
+import { articles, bookmarks, companies, follows } from '../../../../db/schema'
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 50
@@ -17,6 +17,8 @@ export interface ArticleWithCompany {
   publishedAt: string
   feedType: 'tech' | 'press'
   aiSummary: string | null
+  bookmarkCount: number
+  isBookmarked: boolean
   company: {
     id: string
     name: string
@@ -81,6 +83,7 @@ export async function GET(request: NextRequest) {
       publishedAt: articles.publishedAt,
       feedType: articles.feedType,
       aiSummary: articles.aiSummary,
+      bookmarkCount: articles.bookmarkCount,
       companyId: companies.id,
       companyName: companies.name,
       companySlug: companies.slug,
@@ -103,6 +106,17 @@ export async function GET(request: NextRequest) {
         })
       : null
 
+  // ログイン中のユーザーのブックマーク状態を一括取得
+  let bookmarkedIds = new Set<string>()
+  if (userId && data.length > 0) {
+    const articleIds = data.map((r) => r.id)
+    const bRows = await db
+      .select({ articleId: bookmarks.articleId })
+      .from(bookmarks)
+      .where(and(eq(bookmarks.userId, userId), inArray(bookmarks.articleId, articleIds)))
+    bookmarkedIds = new Set(bRows.map((r) => r.articleId))
+  }
+
   const result: ArticleWithCompany[] = data.map((row) => ({
     id: row.id,
     title: row.title,
@@ -111,6 +125,8 @@ export async function GET(request: NextRequest) {
     publishedAt: row.publishedAt.toISOString(),
     feedType: row.feedType,
     aiSummary: row.aiSummary,
+    bookmarkCount: row.bookmarkCount,
+    isBookmarked: bookmarkedIds.has(row.id),
     company: {
       id: row.companyId,
       name: row.companyName,

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 
 import { isSafeUrl } from '@/lib/safeUrl'
+import { BookmarkButton } from './BookmarkButton'
 import type { ArticleWithCompany } from '@/app/api/feed/route'
 
 function formatRelative(iso: string) {
@@ -79,6 +80,13 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
             {article.aiSummary}
           </p>
         )}
+        <div className="mt-1 flex justify-end">
+          <BookmarkButton
+            articleId={article.id}
+            initialIsBookmarked={article.isBookmarked}
+            initialCount={article.bookmarkCount}
+          />
+        </div>
       </div>
 
       {isSafeUrl(article.ogpImageUrl) && (

--- a/src/components/BookmarkButton.tsx
+++ b/src/components/BookmarkButton.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+interface Props {
+  articleId: string
+  initialIsBookmarked: boolean
+  initialCount: number
+}
+
+export function BookmarkButton({ articleId, initialIsBookmarked, initialCount }: Props) {
+  const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked)
+  const [count, setCount] = useState(initialCount)
+  const [isPending, startTransition] = useTransition()
+
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+
+    // 楽観的更新
+    const next = !isBookmarked
+    setIsBookmarked(next)
+    setCount((c) => (next ? c + 1 : Math.max(0, c - 1)))
+
+    startTransition(async () => {
+      try {
+        const res = await fetch('/api/bookmarks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ articleId }),
+        })
+        if (!res.ok) {
+          // ロールバック
+          setIsBookmarked(!next)
+          setCount((c) => (!next ? c + 1 : Math.max(0, c - 1)))
+        }
+      } catch {
+        setIsBookmarked(!next)
+        setCount((c) => (!next ? c + 1 : Math.max(0, c - 1)))
+      }
+    })
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isPending}
+      aria-label={isBookmarked ? 'ブックマーク解除' : 'ブックマーク'}
+      className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs transition-colors ${
+        isBookmarked
+          ? 'text-sg-accent bg-sg-accent-soft'
+          : 'text-sg-ink-faint hover:text-sg-accent hover:bg-sg-accent-soft'
+      }`}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill={isBookmarked ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+      </svg>
+      {count > 0 && <span>{count}</span>}
+    </button>
+  )
+}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -28,6 +28,25 @@ const items = [
     ),
   },
   {
+    href: '/popular',
+    label: '人気',
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+        <polyline points="17 6 23 6 23 12" />
+      </svg>
+    ),
+  },
+  {
     href: '/discover',
     label: '企業を探す',
     icon: (
@@ -43,6 +62,24 @@ const items = [
       >
         <circle cx="11" cy="11" r="8" />
         <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+    ),
+  },
+  {
+    href: '/bookmarks',
+    label: 'ブックマーク',
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
       </svg>
     ),
   },

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -5,7 +5,9 @@ import { usePathname } from 'next/navigation'
 
 const items = [
   { href: '/feed', label: 'フィード' },
+  { href: '/popular', label: '人気記事' },
   { href: '/discover', label: '企業を探す' },
+  { href: '/bookmarks', label: 'ブックマーク' },
   { href: '/mypage', label: 'マイページ' },
 ]
 


### PR DESCRIPTION
## 概要

記事のブックマーク機能と、ブックマーク数でランキングする人気記事ページを追加。

## 変更内容

### DB
- `bookmarks` テーブル: `(user_id, article_id)` 複合PK、`articles_bookmark_count_idx` インデックス付き
- `articles.bookmark_count` 列: 非正規化カウンタ (`integer DEFAULT 0`)、`bookmark_count DESC` インデックス付き

### API
- `POST /api/bookmarks` — ブックマーク追加/解除を atomic increment/decrement でトグル
- `GET /api/articles/popular` — 30日以内の記事を `bookmark_count DESC` で取得

### ページ
- `/bookmarks` — ブックマーク済み記事一覧（ログイン必須、未ログインは `/login` へリダイレクト）
- `/popular` — Tech Blog / プレスリリース フィルタ + 順位番号付きランキング

### コンポーネント
- `BookmarkButton` — 楽観的更新つきトグルボタン。未ログイン時は API が 401 を返し元の状態に戻る
- `ArticleCard` — ブックマークボタンを右下に配置、`bookmarkCount > 0` のとき数を表示
- `SidebarNav` / `BottomNav` — 「人気記事」「ブックマーク」を追加

## マイグレーション

`pnpm db:push` または `pnpm db:migrate` を実行すること。

Closes #67

## テスト方法

- [x] `pnpm build` 成功
- [x] ブックマークボタンを押すと即座にUIが変わる (楽観的更新)
- [x] 未ログイン状態でブックマークボタンを押すと元に戻る
- [x] `/popular` で記事が bookmark_count 順に並ぶ
- [x] `/bookmarks` でブックマーク済み記事一覧が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)