### PR TITLE
fix: バグ9件の修正 + クローラー停止 (4/28以降) の復旧

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -14,8 +14,10 @@ jobs:
     name: Crawl RSS Feeds
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # DATABASE_URL が未登録の場合はジョブをスキップ
-    if: ${{ secrets.DATABASE_URL != '' }}
+    # secrets コンテキストはジョブレベル if では参照できない (ワークフロー全体が
+    # 無効になる) ため、env 経由でステップレベル if により判定する
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout
@@ -36,6 +38,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Crawl
+        if: env.DATABASE_URL != ''
         run: pnpm crawl
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Notice when skipped
+        if: env.DATABASE_URL == ''
+        run: echo "::warning::DATABASE_URL が未設定のためクロールをスキップしました"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ db/                    ← Drizzle スキーマ・マイグレーション・シ
 **コードを変更したら必ず PR を出す。どんな小さな修正でも例外なし。**
 
 手順:
+
 1. `git checkout main && git pull`
 2. `git checkout -b <branch-name>`
 3. 実装・修正

--- a/crawler/store.ts
+++ b/crawler/store.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import type { InferSelectModel } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/neon-http'
 import { neon } from '@neondatabase/serverless'
@@ -20,19 +20,40 @@ type Db = ReturnType<typeof createDb>
 
 export async function storeArticles(db: Db, feed: CompanyFeed, items: FeedItem[]): Promise<number> {
   const validItems = items.flatMap((item) => {
+    // URL か pubDate が不正な記事はスキップし、フィード全体は失敗させない
+    const publishedAt = new Date(item.pubDate)
+    if (Number.isNaN(publishedAt.getTime())) return []
     try {
-      return [{ item, normalized: normalizeUrl(item.link) }]
+      return [{ item, normalized: normalizeUrl(item.link), publishedAt }]
     } catch {
       return []
     }
   })
+  if (validItems.length === 0) return 0
+
+  // 既存記事を除外してから OGP を取得する (毎クロールでの再取得を避ける)
+  const existing = await db
+    .select({ normalizedUrl: schema.articles.normalizedUrl })
+    .from(schema.articles)
+    .where(
+      and(
+        eq(schema.articles.companyId, feed.companyId),
+        inArray(
+          schema.articles.normalizedUrl,
+          validItems.map((v) => v.normalized),
+        ),
+      ),
+    )
+  const existingUrls = new Set(existing.map((e) => e.normalizedUrl))
+  const newItems = validItems.filter((v) => !existingUrls.has(v.normalized))
+  if (newItems.length === 0) return 0
 
   // OGP 画像を並列取得
-  const ogImages = await Promise.all(validItems.map(({ item }) => fetchOgImage(item.link)))
+  const ogImages = await Promise.all(newItems.map(({ item }) => fetchOgImage(item.link)))
 
   let newCount = 0
-  for (let i = 0; i < validItems.length; i++) {
-    const { item, normalized } = validItems[i]
+  for (let i = 0; i < newItems.length; i++) {
+    const { item, normalized, publishedAt } = newItems[i]
     const result = await db
       .insert(schema.articles)
       .values({
@@ -42,7 +63,7 @@ export async function storeArticles(db: Db, feed: CompanyFeed, items: FeedItem[]
         sourceUrl: item.link,
         normalizedUrl: normalized,
         ogpImageUrl: ogImages[i],
-        publishedAt: new Date(item.pubDate),
+        publishedAt,
       })
       .onConflictDoNothing()
       .returning({ id: schema.articles.id })

--- a/src/app/(main)/discover/CompanySearch.tsx
+++ b/src/app/(main)/discover/CompanySearch.tsx
@@ -1,25 +1,39 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useTransition } from 'react'
+import { useCallback, useEffect, useRef, useTransition } from 'react'
+
+const DEBOUNCE_MS = 300
 
 export function CompanySearch() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const q = e.target.value.trim()
-      const params = new URLSearchParams(searchParams.toString())
-      if (q) {
-        params.set('q', q)
-      } else {
-        params.delete('q')
-      }
-      startTransition(() => {
-        router.push(`/discover?${params.toString()}`)
-      })
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        const params = new URLSearchParams(searchParams.toString())
+        if (q) {
+          params.set('q', q)
+        } else {
+          params.delete('q')
+        }
+        const qs = params.toString()
+        startTransition(() => {
+          // push だと1文字ごとに履歴が積まれて戻るボタンが壊れるため replace
+          router.replace(qs ? `/discover?${qs}` : '/discover')
+        })
+      }, DEBOUNCE_MS)
     },
     [router, searchParams],
   )

--- a/src/app/(main)/discover/page.tsx
+++ b/src/app/(main)/discover/page.tsx
@@ -6,6 +6,7 @@ import { CompanyLogo } from '@/components/CompanyLogo'
 import { FollowButton } from '@/components/FollowButton'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db/server'
+import { escapeLike } from '@/lib/escapeLike'
 import { companies, follows } from '../../../../db/schema'
 import { CompanySearch } from './CompanySearch'
 
@@ -35,7 +36,10 @@ export default async function DiscoverPage({ searchParams }: PageProps) {
       .from(companies)
       .where(
         query
-          ? or(ilike(companies.name, `%${query}%`), ilike(companies.slug, `%${query}%`))
+          ? or(
+              ilike(companies.name, `%${escapeLike(query)}%`),
+              ilike(companies.slug, `%${escapeLike(query)}%`),
+            )
           : undefined,
       )
       .orderBy(companies.name)

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -2,6 +2,7 @@ import { ilike, or } from 'drizzle-orm'
 import { type NextRequest } from 'next/server'
 
 import { db } from '@/lib/db/server'
+import { escapeLike } from '@/lib/escapeLike'
 import { companies } from '../../../../db/schema'
 
 export async function GET(request: NextRequest) {
@@ -10,7 +11,14 @@ export async function GET(request: NextRequest) {
   const rows = await db
     .select()
     .from(companies)
-    .where(q ? or(ilike(companies.name, `%${q}%`), ilike(companies.slug, `%${q}%`)) : undefined)
+    .where(
+      q
+        ? or(
+            ilike(companies.name, `%${escapeLike(q)}%`),
+            ilike(companies.slug, `%${escapeLike(q)}%`),
+          )
+        : undefined,
+    )
     .orderBy(companies.name)
     .limit(100)
 

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -8,6 +8,7 @@ import { articles, bookmarks, companies, follows } from '../../../../db/schema'
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 50
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export interface ArticleWithCompany {
   id: string
@@ -34,8 +35,20 @@ export async function GET(request: NextRequest) {
   const type = searchParams.get('type') as 'tech' | 'press' | null
   const following = searchParams.get('following') === 'true'
 
-  const limit = Math.min(Number(limitParam) || DEFAULT_LIMIT, MAX_LIMIT)
+  const parsedLimit = Number(limitParam)
+  const limit =
+    Number.isInteger(parsedLimit) && parsedLimit >= 1
+      ? Math.min(parsedLimit, MAX_LIMIT)
+      : DEFAULT_LIMIT
+
   const cursor = cursorParam ? decodeCursor(cursorParam) : null
+  // カーソル id は uuid カラムと比較するため、形式不正はここで弾く (DB エラー回避)
+  if (cursorParam && (!cursor || !UUID_RE.test(cursor.id))) {
+    return Response.json(
+      { error: { code: 'BAD_REQUEST', message: '無効なカーソルです' } },
+      { status: 400 },
+    )
+  }
 
   const session = await auth()
   const userId = session?.user?.id ?? null

--- a/src/app/api/follows/route.ts
+++ b/src/app/api/follows/route.ts
@@ -8,6 +8,14 @@ import { companies, follows } from '../../../../db/schema'
 
 const bodySchema = z.object({ companyId: z.string().uuid() })
 
+async function parseBody(request: NextRequest): Promise<unknown> {
+  try {
+    return await request.json()
+  } catch {
+    return null
+  }
+}
+
 export async function GET() {
   const session = await auth()
   if (!session) {
@@ -34,7 +42,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const parsed = bodySchema.safeParse(await request.json())
+  const parsed = bodySchema.safeParse(await parseBody(request))
   if (!parsed.success) {
     return Response.json(
       { error: { code: 'BAD_REQUEST', message: '無効なリクエスト' } },
@@ -71,7 +79,7 @@ export async function DELETE(request: NextRequest) {
     )
   }
 
-  const parsed = bodySchema.safeParse(await request.json())
+  const parsed = bodySchema.safeParse(await parseBody(request))
   if (!parsed.success) {
     return Response.json(
       { error: { code: 'BAD_REQUEST', message: '無効なリクエスト' } },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,13 +3,12 @@ import type { MetadataRoute } from 'next'
 import { db } from '@/lib/db/server'
 import { companies } from '../../db/schema'
 
+// ビルド時は DB に接続できない (CI はプレースホルダ URL) ため、リクエスト時に生成する
+export const dynamic = 'force-dynamic'
+
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://signalog.vercel.app'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const companyList = await db
-    .select({ slug: companies.slug, updatedAt: companies.updatedAt })
-    .from(companies)
-
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: `${SITE_URL}/discover`,
@@ -17,6 +16,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 1,
     },
   ]
+
+  let companyList: { slug: string; updatedAt: Date }[] = []
+  try {
+    companyList = await db
+      .select({ slug: companies.slug, updatedAt: companies.updatedAt })
+      .from(companies)
+  } catch {
+    // DB 障害時も静的ページだけの sitemap を返す (500 でクローラーに嫌われない)
+  }
 
   const companyPages: MetadataRoute.Sitemap = companyList.map((c) => ({
     url: `${SITE_URL}/companies/${c.slug}`,

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -42,13 +42,10 @@ function LogoTile({ name, logoUrl }: { name: string; logoUrl: string | null }) {
 
 export function ArticleCard({ article }: { article: ArticleWithCompany }) {
   const safeSourceUrl = isSafeUrl(article.sourceUrl) ? article.sourceUrl : '#'
+  // <a> の入れ子は不正な HTML になるため、記事リンクは after 疑似要素で
+  // カード全体に広げ、企業リンクは z-10 で前面に重ねる
   return (
-    <a
-      href={safeSourceUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group border-sg-line bg-sg-surface hover:border-sg-accent-soft flex gap-4 rounded-2xl border p-4 transition-all hover:shadow-sm"
-    >
+    <div className="group border-sg-line bg-sg-surface hover:border-sg-accent-soft relative flex gap-4 rounded-2xl border p-4 transition-all hover:shadow-sm">
       <LogoTile name={article.company.name} logoUrl={article.company.logoUrl} />
 
       <div className="min-w-0 flex-1">
@@ -64,17 +61,21 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
           </span>
           <Link
             href={`/companies/${article.company.slug}`}
-            className="text-sg-ink-soft hover:text-sg-accent-deep font-medium"
-            onClick={(e) => e.stopPropagation()}
+            className="text-sg-ink-soft hover:text-sg-accent-deep relative z-10 font-medium"
           >
             {article.company.name}
           </Link>
           <span className="text-sg-ink-faint">· {formatRelative(article.publishedAt)}</span>
         </div>
 
-        <p className="text-sg-ink group-hover:text-sg-accent-deep mb-1 line-clamp-2 text-[15px] leading-snug font-semibold">
+        <a
+          href={safeSourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sg-ink group-hover:text-sg-accent-deep mb-1 line-clamp-2 text-[15px] leading-snug font-semibold after:absolute after:inset-0"
+        >
           {article.title}
-        </p>
+        </a>
         {article.aiSummary && (
           <div className="bg-sg-accent-soft/40 mt-2 rounded-lg px-3 py-2">
             <div className="text-sg-accent-deep mb-1 flex items-center gap-1 text-[10px] font-bold tracking-wide uppercase">
@@ -88,7 +89,7 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
             </p>
           </div>
         )}
-        <div className="mt-1 flex justify-end">
+        <div className="relative z-10 mt-1 flex justify-end">
           <BookmarkButton
             articleId={article.id}
             initialIsBookmarked={article.isBookmarked}
@@ -112,6 +113,6 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
           />
         </div>
       )}
-    </a>
+    </div>
   )
 }

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -84,9 +84,7 @@ export function ArticleCard({ article }: { article: ArticleWithCompany }) {
               </svg>
               AI 要約
             </div>
-            <p className="text-sg-ink-soft text-xs leading-relaxed">
-              {article.aiSummary}
-            </p>
+            <p className="text-sg-ink-soft text-xs leading-relaxed">{article.aiSummary}</p>
           </div>
         )}
         <div className="relative z-10 mt-1 flex justify-end">

--- a/src/lib/cursor.test.ts
+++ b/src/lib/cursor.test.ts
@@ -19,4 +19,11 @@ describe('encodeCursor / decodeCursor', () => {
   it('空文字は null を返す', () => {
     expect(decodeCursor('')).toBeNull()
   })
+
+  it('publishedAt が日付として不正な場合は null を返す', () => {
+    const bad = Buffer.from(JSON.stringify({ publishedAt: 'not-a-date', id: 'abc-123' })).toString(
+      'base64url',
+    )
+    expect(decodeCursor(bad)).toBeNull()
+  })
 })

--- a/src/lib/cursor.ts
+++ b/src/lib/cursor.ts
@@ -17,7 +17,8 @@ export function decodeCursor(encoded: string): Cursor | null {
       'publishedAt' in parsed &&
       'id' in parsed &&
       typeof (parsed as Cursor).publishedAt === 'string' &&
-      typeof (parsed as Cursor).id === 'string'
+      typeof (parsed as Cursor).id === 'string' &&
+      !Number.isNaN(Date.parse((parsed as Cursor).publishedAt))
     ) {
       return parsed as Cursor
     }

--- a/src/lib/escapeLike.ts
+++ b/src/lib/escapeLike.ts
@@ -1,0 +1,7 @@
+/**
+ * LIKE / ILIKE パターン内で特別な意味を持つ文字 (% _ \) をエスケープする。
+ * ユーザー入力をそのまま `%${q}%` に埋め込むと「100%」等の検索が意図しないマッチになるため。
+ */
+export function escapeLike(input: string): string {
+  return input.replace(/[\\%_]/g, (c) => `\\${c}`)
+}


### PR DESCRIPTION
## Summary

- **4/28以降クロールが停止していた原因を修正**（最重要）
- 全体のバグ洗い出しで見つかった9件を修正

## 変更内容

### 🔥 クローラー停止の復旧

4/28 のコミット `c27e1ea` で `crawl.yml` に入った `if: ${{ secrets.DATABASE_URL != '' }}`（ジョブレベル）が原因。GitHub Actions では `secrets` コンテキストをジョブレベル `if` で参照できず、**ワークフロー全体が無効**になっていた。

- schedule イベントの実行回数: 4/28以降 **0回**（cron が一度も起動していない）
- 全トリガーがジョブ生成前に即失敗（total_jobs: 0）

`secrets` をジョブ `env` に渡し、ステップレベル `if: env.DATABASE_URL != ''` で判定する方式に修正。ai-summary.yml は `74b9cb8` で同種の修正済みだったが crawl.yml が直っていなかった。

**⚠️ schedule は main の定義で動くため、マージ後に有効化されます。すぐ動かす場合は Actions から手動実行してください。**

### バグ修正（9件）

**重大**
1. **sitemap がビルド時にDB接続して CI が失敗** → `force-dynamic` 化 + DB障害時フォールバック
2. **ArticleCard の `<a>` 入れ子（不正HTML）** — hydration不整合・クリック挙動破綻の原因 → stretched-link パターンに再構築（main のブックマークボタン・AI要約表示とも統合済み。`<a>` 内に `<button>` がある問題も同時に解消）
3. **フィードAPI: カーソル改ざんで500** → 日付検証 + UUID形式チェックで400を返却
4. **フィードAPI: `limit=-5` で500** → 下限1にクランプ
5. **フォローAPI: 不正JSONボディで500** → 400を返却
6. **クローラー: 不正な pubDate でフィード全体が失敗扱い** → 該当記事のみスキップ

**中程度**
7. **クローラー: 既存記事のOGP画像を毎クロール再取得** → 新規記事のみ取得
8. **企業検索: デバウンスなし + `router.push` で履歴汚染** → 300msデバウンス + `replace`
9. **検索の `%` `_` 未エスケープ** — 「100%」等が誤マッチ → `escapeLike` ヘルパーを追加

## Test plan

- [ ] マージ後、Actions で「Crawl RSS Feeds」がワークフロー名で正しく表示される（パス表示は無効の証拠）
- [ ] 手動実行 (workflow_dispatch) でクロールが成功し記事が入る
- [ ] フィードの記事カードで記事リンク・企業リンク・ブックマークがそれぞれ正しく動作する
- [ ] 検索欄に「100%」等を入力しても誤マッチしない
- [ ] `/sitemap.xml` が正しく返る

`tsc` / vitest（5件）/ ESLint / Prettier / 本番ビルドはローカルで通過済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qKw6PKsCa9YGWAhvtF7Li

---
_Generated by [Claude Code](https://claude.ai/code/session_017qKw6PKsCa9YGWAhvtF7Li)_